### PR TITLE
Handle Cloudinary Api errors

### DIFF
--- a/spec/Bex/Behat/ScreenshotExtension/Driver/CloudinarySpec.php
+++ b/spec/Bex/Behat/ScreenshotExtension/Driver/CloudinarySpec.php
@@ -27,7 +27,7 @@ class CloudinarySpec extends ObjectBehavior
         $this->load($container, ['screenshot_directory' => '/tmp/behat-screenshot/', 'cloud_name' => 'X', 'preset' => 'Y']);
 
         $local->upload('imgdata', 'img_file_name.png')->shouldBeCalled()->willReturn('/tmp/behat-screenshot/img_file_name.png');
-        $client->uploadUnsigned('/tmp/behat-screenshot/img_file_name.png')->shouldBeCalled()->willReturn(['secure_url' => 'cloudinary']);
+        $client->uploadUnsigned('/tmp/behat-screenshot/img_file_name.png')->shouldBeCalled()->willReturn(['success' => true, 'secure_url' => 'cloudinary']);
 
         $this->upload('imgdata', 'img_file_name.png')->shouldReturn('cloudinary');
     }
@@ -37,7 +37,7 @@ class CloudinarySpec extends ObjectBehavior
         $this->load($container, ['screenshot_directory' => '/tmp/behat-screenshot/']);
 
         $local->upload('imgdata', 'img_file_name.png')->shouldBeCalled()->willReturn('/tmp/behat-screenshot/img_file_name.png');
-        $client->upload('/tmp/behat-screenshot/img_file_name.png')->shouldBeCalled()->willReturn(['secure_url' => 'cloudinary']);
+        $client->upload('/tmp/behat-screenshot/img_file_name.png')->shouldBeCalled()->willReturn(['success' => true, 'secure_url' => 'cloudinary']);
 
         $this->upload('imgdata', 'img_file_name.png')->shouldReturn('cloudinary');
     }

--- a/src/Cloudinary.php
+++ b/src/Cloudinary.php
@@ -80,6 +80,6 @@ class Cloudinary implements ImageDriverInterface
      */
     private function processResponse($response)
     {
-        return $response['secure_url'];
+        return $response['success'] ? $response['secure_url'] : sprintf('Failure: %s', $response['failureReason']);
     }
 }

--- a/src/CloudinaryClient/CloudinaryClient.php
+++ b/src/CloudinaryClient/CloudinaryClient.php
@@ -6,6 +6,7 @@
 namespace Bex\Behat\ScreenshotExtension\Driver\CloudinaryClient;
 
 use Cloudinary\Uploader;
+use Exception;
 
 class CloudinaryClient implements CloudinaryClientInterface
 {
@@ -17,12 +18,28 @@ class CloudinaryClient implements CloudinaryClientInterface
 
     public function upload($filepath)
     {
-        return Uploader::upload($filepath);
+        try {
+            $response = Uploader::upload($filepath);
+            $response['success'] = true;
+        } catch (Exception $e) {
+            $response['success'] = false;
+            $response['failureReason'] = $e->getMessage();
+        }
+
+        return $response;
     }
 
     public function uploadUnsigned($filepath)
     {
-        return Uploader::unsigned_upload($filepath, $this->preset);
+        try {
+            $response = Uploader::unsigned_upload($filepath, $this->preset);
+            $response['success'] = true;
+        } catch (Exception $e) {
+            $response['success'] = false;
+            $response['failureReason'] = $e->getMessage();
+        }
+
+        return $response;
     }
 
     public function configure($values)


### PR DESCRIPTION
Currently Cloudinary API errors are not handled at all, meaning that if one occurs then the whole test run is stopped (example: https://travis-ci.org/ezsystems/ezplatform/jobs/489258163 )

This PR adds basic error handling, just to make sure that the tests can continue after a failure when taking a screenshot.

If this is accepted I'd like to make a 1.0.1 release with this bugfix.