### PR TITLE
Add constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ default:
                   preset: Y
 ```
 
+Other options:
+- mode: if set to `ci` then will work only on CI environments, not locally. Defaults to `normal`
+- limit: specifies the number of screenshots that can be taken in a single Behat run. It's based on number of files in `screenshot_directory`, so make sure that the folder is empty before the tests are run and cleaned only after the whole suite, not after every test.
+
 Usage
 -----
 

--- a/composer.json
+++ b/composer.json
@@ -8,10 +8,11 @@
     "require": {
         "php" : ">=5.6",
         "behat/behat" : "^3.0.0",
-        "cloudinary/cloudinary_php": "^1.10"
+        "cloudinary/cloudinary_php": "^1.10",
+        "ondram/ci-detector": "^2.1.0"
     },
     "require-dev": {
-        "phpspec/phpspec" : "2.4.0-alpha2",
+        "phpspec/phpspec" : "^2.4.0",
         "bex/behat-extension-driver-locator": "*",
         "bex/behat-screenshot": "*",
         "bex/behat-test-runner": "*",

--- a/features/screenshot.feature
+++ b/features/screenshot.feature
@@ -58,7 +58,7 @@ Feature: Taking screenshot
       }
       """
 
-  Scenario: Save screenshot using Cloudinary unsigned api
+  Scenario: Save screenshot using Cloudinary unsigned api with default config
     Given I have the configuration:
       """
       default:
@@ -78,6 +78,33 @@ Feature: Taking screenshot
                   screenshot_directory: /tmp/behat-screenshot/
                   cloud_name: ezplatformtravis
                   preset: driver
+      """
+    When I run Behat
+    Then I should see a failing test
+    And I should see the cloudinary image url
+
+  Scenario: Save screenshot using Cloudinary unsigned api with limit and normal mode
+    Given I have the configuration:
+      """
+      default:
+        extensions:
+          Behat\MinkExtension:
+            base_url: 'http://localhost:8080'
+            sessions:
+              default:
+                selenium2:
+                  wd_host: http://0.0.0.0:4444/wd/hub
+                  browser: chrome
+
+          Bex\Behat\ScreenshotExtension:
+            active_image_drivers: cloudinary
+            image_drivers:
+                cloudinary:
+                  screenshot_directory: /tmp/behat-screenshot/
+                  cloud_name: ezplatformtravis
+                  preset: driver
+                  mode: normal
+                  limit: 3
       """
     When I run Behat
     Then I should see a failing test

--- a/spec/Bex/Behat/ScreenshotExtension/Driver/CloudinarySpec.php
+++ b/spec/Bex/Behat/ScreenshotExtension/Driver/CloudinarySpec.php
@@ -8,6 +8,7 @@ namespace spec\Bex\Behat\ScreenshotExtension\Driver;
 use Bex\Behat\ScreenshotExtension\Driver\CloudinaryClient\CloudinaryClient;
 use Bex\Behat\ScreenshotExtension\Driver\Local;
 use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class CloudinarySpec extends ObjectBehavior
@@ -24,9 +25,9 @@ class CloudinarySpec extends ObjectBehavior
 
     public function it_should_call_the_unsigned_api_with_the_correct_data(ContainerBuilder $container, Local $local, CloudinaryClient $client)
     {
-        $this->load($container, ['screenshot_directory' => '/tmp/behat-screenshot/', 'cloud_name' => 'X', 'preset' => 'Y']);
+        $this->load($container, ['screenshot_directory' => '/tmp/behat-screenshot/', 'cloud_name' => 'X', 'preset' => 'Y', 'mode' => 'normal', 'limit' => -1]);
 
-        $local->upload('imgdata', 'img_file_name.png')->shouldBeCalled()->willReturn('/tmp/behat-screenshot/img_file_name.png');
+        $local->upload('imgdata', Argument::containingString('img_file_name.png'))->shouldBeCalled()->willReturn('/tmp/behat-screenshot/img_file_name.png');
         $client->uploadUnsigned('/tmp/behat-screenshot/img_file_name.png')->shouldBeCalled()->willReturn(['success' => true, 'secure_url' => 'cloudinary']);
 
         $this->upload('imgdata', 'img_file_name.png')->shouldReturn('cloudinary');
@@ -34,9 +35,9 @@ class CloudinarySpec extends ObjectBehavior
 
     public function it_should_call_the_signed_api_with_the_correct_data(ContainerBuilder $container, Local $local, CloudinaryClient $client)
     {
-        $this->load($container, ['screenshot_directory' => '/tmp/behat-screenshot/']);
+        $this->load($container, ['screenshot_directory' => '/tmp/behat-screenshot/', 'mode' => 'normal', 'limit' => -1]);
 
-        $local->upload('imgdata', 'img_file_name.png')->shouldBeCalled()->willReturn('/tmp/behat-screenshot/img_file_name.png');
+        $local->upload('imgdata', Argument::containingString('img_file_name.png'))->shouldBeCalled()->willReturn('/tmp/behat-screenshot/img_file_name.png');
         $client->upload('/tmp/behat-screenshot/img_file_name.png')->shouldBeCalled()->willReturn(['success' => true, 'secure_url' => 'cloudinary']);
 
         $this->upload('imgdata', 'img_file_name.png')->shouldReturn('cloudinary');

--- a/src/Constraint/CiConstraint.php
+++ b/src/Constraint/CiConstraint.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace Bex\Behat\ScreenshotExtension\Driver\Constraint;
+
+use OndraM\CiDetector\CiDetector;
+
+class CiConstraint implements Constraint
+{
+    const MODE_NAME = 'ci';
+
+    public function canUpload()
+    {
+        $ciDetector = new CiDetector();
+
+        return $ciDetector->isCiDetected();
+    }
+
+    public function getReason()
+    {
+        return 'Screenshots disabled on non-CI environments.';
+    }
+}

--- a/src/Constraint/Constraint.php
+++ b/src/Constraint/Constraint.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace Bex\Behat\ScreenshotExtension\Driver\Constraint;
+
+interface Constraint
+{
+    public function canUpload();
+
+    public function getReason();
+}

--- a/src/Constraint/ConstraintList.php
+++ b/src/Constraint/ConstraintList.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace Bex\Behat\ScreenshotExtension\Driver\Constraint;
+
+class ConstraintList implements Constraint
+{
+    /** @var Constraint[] */
+    private $constraints;
+
+    public function __construct()
+    {
+        $this->constraints = [];
+    }
+
+    public function canUpload()
+    {
+        foreach ($this->constraints as $constraint) {
+            if (!$constraint->canUpload()) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public function getReason()
+    {
+        $reason = '';
+
+        foreach ($this->constraints as $constraint) {
+            if (!$constraint->canUpload()) {
+                $reason = $reason . ' ' . $constraint->getReason();
+            }
+        }
+
+        return $reason;
+    }
+
+    public function add(Constraint $constraint)
+    {
+        $this->constraints[] = $constraint;
+    }
+}

--- a/src/Constraint/LimitConstraint.php
+++ b/src/Constraint/LimitConstraint.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace Bex\Behat\ScreenshotExtension\Driver\Constraint;
+
+use FilesystemIterator;
+
+class LimitConstraint implements Constraint
+{
+    /** @var int */
+    private $limit;
+
+    /** @var string */
+    private $savePath;
+
+    public function __construct($limit, $savePath)
+    {
+        $this->limit = $limit;
+        $this->savePath = $savePath;
+    }
+
+    public function canUpload()
+    {
+        return $this->getNumberOfScreenshotsTaken() < $this->limit;
+    }
+
+    public function getReason()
+    {
+        return sprintf('Limit of %s screenshots exceeded', $this->limit);
+    }
+
+    private function getNumberOfScreenshotsTaken()
+    {
+        $fi = new FilesystemIterator($this->savePath, FilesystemIterator::SKIP_DOTS);
+
+        return iterator_count($fi);
+    }
+}


### PR DESCRIPTION
This PR adds two constraints: mode and limit
```
Bex\Behat\ScreenshotExtension:
            active_image_drivers: cloudinary
            image_drivers:
                cloudinary:
                  screenshot_directory: /tmp/behat-screenshot/
                  cloud_name: ezplatformtravis
                  preset: driver
                  mode: normal
                  limit: 3
```

Mode allows to specify whether the screenshots will be taken everywhere (also locally) or only on CI. (I don't intend to enable it in our settings for now).
Limit allows to specify the maximum number of screenshots taken in a single test run (it's disabled by default - I want to enable it in our settings). It's based on number of files present on disk, I don't see any other way to do this (considering we're about to introduce parallelism that makes everything harder).