### PR TITLE
Added support for PHP8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,31 @@ on:
   pull_request: ~
 
 jobs:
+  cs-fix:
+    name: Run code style check
+    runs-on: "ubuntu-20.04"
+    strategy:
+      matrix:
+        php:
+          - '8.0'
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup PHP Action
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+          extensions: 'pdo_sqlite, gd'
+          tools: cs2pr
+
+      - uses: "ramsey/composer-install@v1"
+        with:
+          dependency-versions: "highest"
+
+      - name: Run code style check
+        run: composer run-script check-cs -- --format=checkstyle | cs2pr
+
   tests:
     name: Tests
     runs-on: "ubuntu-20.04"
@@ -21,7 +46,11 @@ jobs:
           - '7.2'
           - '7.3'
           - '7.4'
+          - '8.0'
         composer_options: [ "" ]
+        include:
+            - php: '8.1'
+              composer_options: "--ignore-platform-req php"
 
     steps:
       - uses: actions/checkout@v2
@@ -41,9 +70,6 @@ jobs:
 
       - name: Setup problem matchers for PHPUnit
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
-
-      - name: Run code style check
-        run: composer run-script check-cs -- --format=checkstyle | cs2pr
 
       - name: Run test suite
         run: composer run-script --timeout=600 test

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://github.com/ezsystems/behat-screenshot-image-driver-cloudinary",
     "license": "GPL-2.0-only",
     "require": {
-        "php" : "^7.1",
+        "php" : "^7.1 || ^8.0",
         "behat/behat" : "^3.7",
         "cloudinary/cloudinary_php": "^1.10"
     },


### PR DESCRIPTION
Allows to use this package together with PHP 8 and 8.1

`ignore-platform-req=php` has to be used because of PHPSpec (dev-only package) that does not support PHP8.1 yet.